### PR TITLE
Fix: Makefileの依存関係とPATHの問題

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ dep:
 	go install -v github.com/mna/pigeon@latest
 	go install -v github.com/Bin-Huang/newc@latest
 	go install -v github.com/dmarkham/enumer@latest
+	go install -v github.com/rakyll/gotest@latest
 	go mod download
 	go mod tidy
 

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,12 @@ KILL_DEAD_CODE = find . -type f -name "*.go" -exec sed -i -E '/^\s*\/\/.*(remove
 
 all: build test
 
-build: dep gen
+build: gen
 	go build ./...
 	$(GOBUILD) -v -o $(BIN) ./cmd/gosk
 
-test:
-	go install -v github.com/rakyll/gotest@latest
+test: dep
+	export PATH=$(shell go env GOPATH)/bin:$(shell go env GOROOT)/bin:$$PATH; \
 	$(GOTEST) -v ./...
 
 clean:
@@ -24,7 +24,8 @@ clean:
 run: build
 	./$(BIN)
 
-gen:
+gen: dep
+	export PATH=$(shell go env GOPATH)/bin:$(shell go env GOROOT)/bin:$$PATH; \
 	go generate ./...
 
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Go parameters
 GOBUILD=go build
-GOTEST=gotest
+GOTEST=$(shell go env GOPATH)/bin/gotest
 
 BIN=gosk
 NASK=wine nask.exe


### PR DESCRIPTION
- 'dep' ターゲットが 'gen' ターゲットの前に呼び出されるようにする対応
- Go ツールを見つけるために、'gen' および 'test' ターゲットに PATH を明示的に設定