### PR TITLE
GoのバージョンとGitHub Actionを更新し、カバレッジ レポートを追加

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,14 +13,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.22.0'
+          go-version: '1.24.4'
 
       # go.mod / go.sumを使ったモジュールをキャッシュ
       - name: Cache Go modules
@@ -32,5 +32,16 @@ jobs:
           restore-keys: ${{ runner.os }}-go-mod-
 
       - name: Build
-        run: make
+        run: make build
+
+      - name: Test with Coverage
+        run: |
+          go test -v -coverprofile=coverage.out ./...
+          go tool cover -html=coverage.out -o coverage.html
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.html
 


### PR DESCRIPTION
- go.mod と一致するように、.github/workflows/go.yml の Go バージョンを 1.24.4 に更新しました。
- actions/checkout を v4、actions/setup-go を v5、actions/upload-artifact を v4 に更新しました。
- `make test` 中に HTML カバレッジレポートを生成する手順を追加しました。
- カバレッジレポートを CI アーティファクトとしてアップロードする手順を追加しました。